### PR TITLE
Juancho

### DIFF
--- a/builtins/echo.c
+++ b/builtins/echo.c
@@ -6,46 +6,43 @@
 /*   By: jarregui <jarregui@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/02 00:14:01 by jarregui          #+#    #+#             */
-/*   Updated: 2025/08/05 17:13:21 by jarregui         ###   ########.fr       */
+/*   Updated: 2025/08/06 18:45:27 by jarregui         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
 
-void	ft_echo(t_shell *shell, char **tokens)
+void	ft_echo(t_shell *shell)
 {
 	int	i;
 	int	suppress_nl;
 	int	supress_first;
 
-	// printf("imprimiendo tokens que nos llegan: \n");
-	// print_tokens(tokens);
-
-
+	print_tokens(shell->tokens);
 	i = 1;
 	suppress_nl = 0;
 	supress_first = 1;
-	while (tokens[i])
+	while (shell->tokens[i])
 	{
-		if (ft_strcmp(tokens[i], "-n") == 0 && supress_first)
+		if (ft_strcmp(shell->tokens[i], "-n") == 0 && supress_first)
 			suppress_nl = 1;
 		else
 		{
 			supress_first = 0;
-			if (tokens[i][0] == '$')
+			if (shell->tokens[i][0] == '$')
 			{
-				if (tokens[i][1] == '?' && tokens[i][2] == '\0')
+				if (shell->tokens[i][1] == '?' && shell->tokens[i][2] == '\0')
 					printf("%d", shell->last_status);  // echo $?
 				else
 				{
-					char *val = ft_getenv(shell, tokens[i] + 1); // salta '$'
+					char *val = ft_getenv(shell, shell->tokens[i] + 1); // salta '$'
 					if (val)
 						printf("%s", val);
 				}
 			}
 			else
-				printf("%s", tokens[i]);
-			if (tokens[i + 1])
+				printf("%s", shell->tokens[i]);
+			if (shell->tokens[i + 1])
 				printf(" ");
 		}
 		i++;

--- a/builtins/export.c
+++ b/builtins/export.c
@@ -6,7 +6,7 @@
 /*   By: jarregui <jarregui@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/31 13:54:59 by jarregui          #+#    #+#             */
-/*   Updated: 2025/08/04 19:29:50 by jarregui         ###   ########.fr       */
+/*   Updated: 2025/08/06 18:49:27 by jarregui         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,21 +54,22 @@ void	ft_env_set(t_shell *shell, const char *entry)
 	shell->env = new;
 }
 
-void	ft_export(t_shell *shell, char **tokens)
+void	ft_export(t_shell *shell)
 {
-	int	i = 1;
+	int	i;
 
-	while (tokens[i])
+	i = 1;
+	while (shell->tokens[i])
 	{
-		if (!is_valid_key(tokens[i]))
+		if (!is_valid_key(shell->tokens[i]))
 		{
-			printf("export: `%s': not a valid identifier\n", tokens[i]);
+			printf("export: `%s': not a valid identifier\n", shell->tokens[i]);
 			shell->last_status = 1;
 		}
 		else
 		{
 			// busca si ya existe
-			ft_env_set(shell, tokens[i]); // actualiza o añade
+			ft_env_set(shell, shell->tokens[i]); // actualiza o añade
 			shell->last_status = 0;
 		}
 		i++;

--- a/builtins/history.c
+++ b/builtins/history.c
@@ -6,25 +6,25 @@
 /*   By: jarregui <jarregui@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/04 01:23:43 by jarregui          #+#    #+#             */
-/*   Updated: 2025/08/04 19:29:50 by jarregui         ###   ########.fr       */
+/*   Updated: 2025/08/07 01:18:07 by jarregui         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
 
-void	ft_add_history(char *line, t_shell *shell)
+void	ft_add_history(t_shell *shell)
 {
 	t_hist	*new_hist;
 	t_hist	*last_hist;
 
-	add_history(line);
+	add_history(shell->line);
 	new_hist = malloc(sizeof(t_hist));
 	if (!new_hist)
 	{
 		perror("Memory allocation failed for history node");
 		return ;
 	}
-	new_hist->line = ft_strdup(line);
+	new_hist->line = ft_strdup(shell->line);
 	new_hist->next = NULL;
 	if (!shell->hist)
 		shell->hist = new_hist;

--- a/builtins/unset.c
+++ b/builtins/unset.c
@@ -6,23 +6,23 @@
 /*   By: jarregui <jarregui@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/31 13:54:59 by jarregui          #+#    #+#             */
-/*   Updated: 2025/08/04 19:29:50 by jarregui         ###   ########.fr       */
+/*   Updated: 2025/08/06 18:50:50 by jarregui         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
 
-void	ft_unset(t_shell *shell, char **tokens)
+void	ft_unset(t_shell *shell)
 {
 	int		i = 1;
 	t_env	*prev = NULL;
 	t_env	*curr = shell->env;
 
-	while (tokens[i])
+	while (shell->tokens[i])
 	{
-		if (!is_valid_key(tokens[i]))
+		if (!is_valid_key(shell->tokens[i]))
 		{
-			printf("unset: `%s': not a valid identifier\n", tokens[i]);
+			printf("unset: `%s': not a valid identifier\n", shell->tokens[i]);
 			shell->last_status = 1;
 			i++;
 			continue;
@@ -31,8 +31,8 @@ void	ft_unset(t_shell *shell, char **tokens)
 		curr = shell->env;
 		while (curr)
 		{
-			if (ft_strncmp(curr->value, tokens[i], ft_strlen(tokens[i])) == 0
-				&& curr->value[ft_strlen(tokens[i])] == '=')
+			if (ft_strncmp(curr->value, shell->tokens[i], ft_strlen(shell->tokens[i])) == 0
+				&& curr->value[ft_strlen(shell->tokens[i])] == '=')
 			{
 				if (prev)
 					prev->next = curr->next;

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@
 #    By: jarregui <jarregui@student.42madrid.com    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/08/04 18:59:16 by jarregui          #+#    #+#              #
-#    Updated: 2025/08/06 18:17:52 by jarregui         ###   ########.fr        #
+#    Updated: 2025/08/07 01:51:13 by jarregui         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -39,6 +39,7 @@ SRCS 	= builtins/echo.c \
 		builtins/unset.c \
 		srcs/execute.c \
 		srcs/main.c \
+		srcs/readline.c \
 		srcs/redirect.c \
 		srcs/signals.c \
 		srcs/token.c \
@@ -83,10 +84,11 @@ debug: fclean
 	@echo "$(GREEN)DEBUG: 🔍 Launching Valgrind with debug build...$(DEF_COLOR)\n"
 	@echo "$(CYAN)💧 Valgrind launched$(DEF_COLOR)"
 	@$(VALGRIND) ./$(EXEC_FILE_NAME) 2>&1 | tee valgrind.log
+	@echo "$(YELLOW)⚠️ Note: memory still reachable is due to readline and is not considered leak$(DEF_COLOR)"
 	@echo "$(CYAN)💧 Leak Summary (if any):$(DEF_COLOR)"
-	@grep -A5 "LEAK SUMMARY:" valgrind.log > /dev/null && \
-		(echo "$(RED)❌ MEM LEAK DETECTED! Check summary at valgrind.log$(DEF_COLOR)"; grep -A5 "LEAK SUMMARY:" valgrind.log) || \
-		echo "$(GREEN)✅ No leaks detected$(DEF_COLOR)"
+	@grep -q "definitely lost: 0 bytes in 0 blocks" valgrind.log && \
+		echo "$(GREEN)✅ No memory leaks detected$(DEF_COLOR)" || \
+		(echo "$(RED)❌ MEM LEAK DETECTED! Check summary at valgrind.log$(DEF_COLOR)"; grep -A5 "LEAK SUMMARY:" valgrind.log)
 	
 clean:
 	@${RM} ${OBJS} ${OBJS_BONUS} $(OBJS:.o=.d) $(OBJS_BONUS:.o=.d) valgrind.log

--- a/minishell.h
+++ b/minishell.h
@@ -51,11 +51,13 @@ typedef struct s_shell //para los datos que necesitaremos en la minishell
 	char			*cwd;
 	char			*prompt;
 	int				exit;
-	int				last_status; //para almacenar el último estado de salida de un comando $?
+	int				last_status;
+	char			*line;
+	char			**tokens;
 }	t_shell;
 
 //builtins/echo.c
-void	ft_echo(t_shell *shell, char **tokens);
+void	ft_echo(t_shell *shell);
 
 
 void	ft_init_shell(t_shell *shell, char **env);
@@ -70,19 +72,23 @@ void	ft_free_env(t_shell *shell);
 //builtins/export.c
 int		is_valid_key(const char *key);
 void	ft_env_set(t_shell *shell, const char *entry);
-void	ft_export(t_shell *shell, char **tokens);
+void	ft_export(t_shell *shell);
 
 //builtins/history.c
-void	ft_add_history(char *line, t_shell *shell);
+void	ft_add_history(t_shell *shell);
 void	ft_print_history(t_shell *shell);
 void	ft_free_history(t_shell *shell);
 
 //builtins/unset.c
-void	ft_unset(t_shell *shell, char **tokens);
+void	ft_unset(t_shell *shell);
 
 
 //srcs/execute.c
-int		ft_execute(char **array, t_shell *shell);
+int		ft_execute(t_shell *shell);
+
+//srcs/readline.c
+void	ft_readline(t_shell *shell);
+void	ft_free_line(t_shell *shell);
 
 //srcs/redirect.c
 // static int	duplication(char *filename);
@@ -95,8 +101,9 @@ void	ft_setup_signals_prompt(void);
 void	ft_setup_signals_child(void);
 
 //token.c
-char	**split_line(char *line);
+void	split_line(t_shell *shell);
 int		print_tokens(char **tokens);
+void	ft_free_tokens(char **tokens);
 
 //utils.c
 void	ft_init_shell(t_shell *shell, char **env);

--- a/minishell.h
+++ b/minishell.h
@@ -7,6 +7,10 @@
 # define STDOUT 1
 # define STDERR 2
 
+# ifndef DEBUG
+#  define DEBUG 0
+# endif
+
 # include "libs/libft/libft.h"
 # include <stdio.h>
 # include <ctype.h>

--- a/srcs/execute.c
+++ b/srcs/execute.c
@@ -6,31 +6,33 @@
 /*   By: jarregui <jarregui@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/02 19:47:59 by jarregui          #+#    #+#             */
-/*   Updated: 2025/08/04 20:10:16 by jarregui         ###   ########.fr       */
+/*   Updated: 2025/08/06 19:09:12 by jarregui         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
 
-int	ft_execute(char **array, t_shell *shell)
+int	ft_execute(t_shell *shell)
 {
 	pid_t	pid;
+	char	*command;
 
-	if (ft_strcmp(array[0], "exit") == 0)
+	command = shell->tokens[0];
+	if (ft_strcmp(command, "exit") == 0)
 		shell->exit = 1;
-	else if (ft_strcmp(array[0], "pwd") == 0)
+	else if (ft_strcmp(command, "pwd") == 0)
 		printf("%s\n", shell->cwd);
-	else if (ft_strcmp(array[0], "echo") == 0)
-		ft_echo(shell, array); 
-	// else if (ft_strcmp(array[0], "cd") == 0) // a implementar solo con una ruta relativa o absoluta.
+	else if (ft_strcmp(command, "echo") == 0)
+		ft_echo(shell); 
+	// else if (ft_strcmp(command, "cd") == 0) // a implementar solo con una ruta relativa o absoluta.
 	// 	printf("cd command not implemented yet.\n");
-	else if (ft_strcmp(array[0], "export") == 0)
-		ft_export(shell, array);
-	else if (ft_strcmp(array[0], "unset") == 0)
-		ft_unset(shell, array);
-	else if (ft_strcmp(array[0], "history") == 0)
+	else if (ft_strcmp(command, "export") == 0)
+		ft_export(shell);
+	else if (ft_strcmp(command, "unset") == 0)
+		ft_unset(shell);
+	else if (ft_strcmp(command, "history") == 0)
 		ft_print_history(shell);
-	else if (ft_strcmp(array[0], "env") == 0)
+	else if (ft_strcmp(command, "env") == 0)
 		ft_print_env(shell);
 	else
 	{
@@ -45,11 +47,11 @@ int	ft_execute(char **array, t_shell *shell)
 		{
 			// Proceso hijo
 			ft_setup_signals_child(); // ← para Ctrl+C y Ctrl+\ se comporten como en bash
-			execvp(array[0], array); // Busca el binario en el PATH
+			execvp(command, shell->tokens); // Busca el binario en el PATH
 			if (errno == ENOENT)
-				printf("command not found: %s\n", array[0]);
+				printf("command not found: %s\n", command);
 			else
-				perror(array[0]); // imprime mensaje detallado del sistema
+				perror(command); // imprime mensaje detallado del sistema
 			exit(127);// Código estándar: comando no encontrado
 		}
 		else

--- a/srcs/execute.c
+++ b/srcs/execute.c
@@ -6,7 +6,7 @@
 /*   By: jarregui <jarregui@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/02 19:47:59 by jarregui          #+#    #+#             */
-/*   Updated: 2025/08/06 19:09:12 by jarregui         ###   ########.fr       */
+/*   Updated: 2025/08/07 02:11:02 by jarregui         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,8 @@ int	ft_execute(t_shell *shell)
 	pid_t	pid;
 	char	*command;
 
+	if (!shell->tokens || !shell->tokens[0])
+		return (0);
 	command = shell->tokens[0];
 	if (ft_strcmp(command, "exit") == 0)
 		shell->exit = 1;

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: jarregui <jarregui@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/01 23:47:36 by jarregui          #+#    #+#             */
-/*   Updated: 2025/08/05 17:40:55 by jarregui         ###   ########.fr       */
+/*   Updated: 2025/08/07 02:01:21 by jarregui         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,9 @@
 	//echo -n: implementada la opción -n para no añadir salto de línea al final.
 	//$?: actualizado en shell->last_status tras la ejecución de un comando externo y los builtins pero hay que checarlo bien
 //Makefile y añadido libft
-
+//Make: que no haga RELINK el makefile
+//Make: añadir versión Debug para checar leaks y errores de memoria
+//he modificado tokens y line y las he incluido en la estructura shell, para que se liberen al salir de la minishell y no haya fugas de memoria.
 
 
 //PENDIENTE BRIAN
@@ -35,8 +37,6 @@
 //revisar tokenización y split_line
 
 //PENDIENTE JUANCHO
-//Make: que no haga RELINK el makefile
-//Make: añadir versión Debug para checar leaks y errores de memoria
 //$crear y borrar variables de entorno (revisar export)
 //Señales. Lo tengo casi. Continuar con las señales
 //Norminette: quitar comentarios y ver longitudes de funciones y num variables
@@ -48,36 +48,26 @@
 
 int	main(int ac, char **av, char **env)
 {
-	char	*line;
-	char	**array;
 	t_shell	shell;
 
-	(void)ac; //ignoramos estos parámetros que no usamos
-	(void)av; //ignoramos estos parámetros que no usamos
-	ft_init_shell(&shell, env); // Inicializamos la estructura shell
+	(void)ac;
+	(void)av;
+	ft_init_shell(&shell, env);
 
 	while (shell.exit == 0)
 	{
-		ft_build_prompt(&shell); // Construimos el prompt con el directorio actual
+		ft_build_prompt(&shell);
 		ft_setup_signals_prompt();
-		line = readline(shell.prompt); //aquí imprimimos el prompt y se queda a la espera para leer la línea que introduzcamos. Es una función estandar de C con readline.h
-		if (line && *line)
-			ft_add_history(line, &shell); // si introducimos algo que no sea nulo o vacío, lo añadimos al historial.
-		if (!line) // Ctrl+D
-			break;
-
-		array = split_line(line);
-		if (!array || !array[0])
-		{
-			free(line);
-			continue;
-		}
-		ft_execute(array, &shell); // Ejecutamos el comando introducido
-		
-		//print_tokens(array);		  // Comprobar que los tokens se parsean correctamente
-
-		free(line);
-		free(array);
+		ft_readline(&shell);
+		if (!shell.line)
+			break ;
+		if (*shell.line == '\0')
+			continue ;
+		ft_add_history(&shell);
+		split_line(&shell);
+		if (!shell.tokens || !shell.tokens[0])
+			continue ;
+		ft_execute(&shell);
 	}
 	ft_exit_shell(&shell);
 }

--- a/srcs/readline.c
+++ b/srcs/readline.c
@@ -1,0 +1,26 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   readline.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: jarregui <jarregui@student.42madrid.com    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/08/07 01:24:42 by jarregui          #+#    #+#             */
+/*   Updated: 2025/08/07 01:29:31 by jarregui         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../minishell.h"
+
+void	ft_readline(t_shell *shell)
+{
+	ft_free_line(shell);
+	shell->line = readline(shell->prompt);
+}
+
+void	ft_free_line(t_shell *shell)
+{
+	if (shell->line)
+		free(shell->line);
+	shell->line = NULL;
+}

--- a/srcs/token.c
+++ b/srcs/token.c
@@ -1,28 +1,32 @@
 #include "../minishell.h"
 
-char **split_line(char *line)
+void	split_line(t_shell *shell)
 {
 	size_t		start;
 	size_t		length;
 	size_t		token_length;
-	char 		*token;
 	size_t		end;
 	size_t		bufsize = BUFSIZ;
 	size_t		position = 0;
-	char		**tokens;
+	size_t		i;
+	char 		*token;
+	char		**new_tokens;
 
+	if (shell->tokens)
+		ft_free_tokens(shell->tokens); // Limpiar tokens anteriores
+	shell->tokens = NULL; // Inicializar tokens a NULL
 	start = 0;
-	length = ft_strlen(line);
-	tokens = malloc(bufsize * sizeof(char *));
-	if (!tokens)
+	length = ft_strlen(shell->line);
+	shell->tokens = malloc(bufsize * sizeof(char *));
+	if (!shell->tokens)
 	{
-		perror("malloc");
-		return NULL;
+		perror("malloc shell->tokens");
+		return ;
 	}
 	while (start < length)
 	{
 		// Saltar espacios en blanco
-		while (start < length && ft_isspace((unsigned char)line[start]))
+		while (start < length && ft_isspace((unsigned char)shell->line[start]))
 			start++;
 
 		/*
@@ -32,54 +36,79 @@ char **split_line(char *line)
 		*/
 
 		if (start == length)
-			break;
+			break ;
 		end = start;
-		while (end < length && !ft_isspace((unsigned char)line[end]))
+		while (end < length && !ft_isspace((unsigned char)shell->line[end]))
 			end++;
 		token_length = end - start;
 		token = malloc(token_length + 1);
 		if (!token)															   // Reconstruir esto, crear la parte de limpieza
 		{
-			perror("malloc");
-			for (size_t i = 0; i < position; i++)
-				free(tokens[i]);
-			free(tokens);
-			return NULL;
+			perror("malloc token");
+			ft_free_tokens(shell->tokens);
+			return ;
 		}
-		strncpy(token, &line[start], token_length);						   // mi ft_strcpy tiene algun fallo porque no funciona bien y por eso uso este
+		strncpy(token, &shell->line[start], token_length);						   // mi ft_strcpy tiene algun fallo porque no funciona bien y por eso uso este
 		token[token_length] = '\0';
-		tokens[position++] = token;
+		shell->tokens[position++] = token;
 		if (position >= bufsize)
 		{
 			bufsize *= 2;
-			char **new_tokens = realloc(tokens, bufsize * sizeof(char *));	 // cambiar esto, no puedo usar realloc ni for!!!!!
+			new_tokens = malloc(bufsize * sizeof(char *));
 			if (!new_tokens)
 			{
-				perror("realloc");
-				// Liberar tokens previos
-				for (size_t i = 0; i < position; i++)
-					free(tokens[i]);
-				free(tokens);
-				return NULL;
+				perror("malloc new_tokens");
+				ft_free_tokens(shell->tokens);
+				return ;
 			}
-			tokens = new_tokens;
+			i = 0;
+			while (i < position)
+			{
+				new_tokens[i] = shell->tokens[i];
+				i++;
+			}
+			free(shell->tokens);
+			shell->tokens = new_tokens;
 		}
 		start = end;
 	}
-	tokens[position] = NULL; // Terminar con NULL
-	return (tokens);
+	shell->tokens[position] = NULL; // Terminar con NULL
+	return ;
 }
 
 int	print_tokens(char **tokens)
 {
+	size_t	i;
+
 	if (!tokens)
-		return 1;
-	for (size_t i = 0; tokens[i] != NULL; i++)
+		return (1);
+	i = 0;
+	if (DEBUG)
 	{
-		printf("Token[%zu]: '%s'\n", i, tokens[i]);
-		// free(tokens[i]);
+		printf("DEBUG: imprimiendo tokens que nos llegan: \n");
+		while (tokens[i])
+		{
+			printf("Token[%zu]: '%s'\n", i, tokens[i]);
+			i++;
+		}
 	}
-	return 0;
+	return (0);
+}
+
+void	ft_free_tokens(char **tokens)
+{
+	size_t	i;
+
+	if (!tokens)
+		return;
+	i = 0;
+	while (tokens[i])
+	{
+		free(tokens[i]);
+		i++;
+	}
+	free(tokens);
+	tokens = NULL;
 }
 
 // Para probar:

--- a/srcs/utils.c
+++ b/srcs/utils.c
@@ -6,7 +6,7 @@
 /*   By: jarregui <jarregui@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/02 00:12:49 by jarregui          #+#    #+#             */
-/*   Updated: 2025/08/04 19:29:50 by jarregui         ###   ########.fr       */
+/*   Updated: 2025/08/07 01:29:52 by jarregui         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,8 @@ void	ft_init_shell(t_shell *shell, char **env)
 	shell->hist = NULL;
 	shell->last_status = 0;
 	shell->exit = 0;
+	shell->line = NULL;
+	shell->tokens = NULL;
 }
 
 int	ft_exit_shell(t_shell *shell)
@@ -30,6 +32,8 @@ int	ft_exit_shell(t_shell *shell)
 		free(shell->cwd);
 	ft_free_history(shell);
 	ft_free_env(shell);
+	ft_free_line(shell);
+	ft_free_tokens(shell->tokens);
 	printf("\033[1;32mExiting minishell...\033[0m\n");
 	exit(0);
 }


### PR DESCRIPTION
He modificado el makefile para que no haga RELINK
También he añadido una regla "Debug" para checar leaks y errores de memoria.
He modificado el array de los tokens y line, añadiendole directamente a la estructura shell. Así se libera mejor la memoria de estos dos casos antes de cada uso, y también cuando queremos salir.
también he corregido la función split_line (además de para cambiar que tokens ahora va directamente en shell) para quitar el realloc que también me daba problemas de memoria.
Hasta donde he checado ahora mismo ya no hay memory leaks.
si haces "make debug" verás que al salir suelta un log con muchas cosas y dice que hay "memory still recheable" pero a eso no hay que hacerle caso que es culpa de realine. Solo tienes que preocuparte si ves "memory lost"
